### PR TITLE
Corrected symfony version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,11 @@
 	],
 	"require": {
 		"php": ">=5.4.0",
-		"symfony/http-kernel": "~2.5",
+		"symfony/http-kernel": "~2.5.12|~2.6.8|~2.7",
 		"league/route": "~1.0",
 		"league/container": "~1.0",
 		"league/event": "~2.1",
 		"monolog/monolog": "~1.12"
-	},
-	"conflict": {
-		"symfony/http-kernel": ">=2.6.0,<2.6.6"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0"


### PR DESCRIPTION
We now require non-vulnerable symfony http kernel versions as defined by https://security.sensiolabs.org/database?package=symfony/http-kernel.